### PR TITLE
Simplification de l’écran de confirmation abonnement (Issue #9)

### DIFF
--- a/app/(drawer)/subscription.tsx
+++ b/app/(drawer)/subscription.tsx
@@ -185,7 +185,7 @@ export default function SubscriptionScreen() {
       const planToUpgrade = plans.find(p => p.id === selectedPlan);
 
       if (planToUpgrade) {
-        showModal('success', 'Bravo ! 🎉', `Vous avez désormais accès au pack ${planToUpgrade.name}`);
+        showModal('success', 'Bravo ! 🎉', `Désormais vous avez accès au pack ${planToUpgrade.name}`);
       }
 
       setTimeout(() => {


### PR DESCRIPTION
Simplifier l’écran de confirmation après paiement pour améliorer l’expérience utilisateur et éviter toute frustration.

